### PR TITLE
escape <marker> in error messages

### DIFF
--- a/grails-app/i18n/messages_en.properties
+++ b/grails-app/i18n/messages_en.properties
@@ -187,11 +187,11 @@ ltc.editor.help.question.mark=matches the word "walk" or "walks", i.e. the "s" i
 ltc.editor.continue=Continue
 ltc.editor.error.not.found=The rule did not find the expected error in ''{0}''
 ltc.editor.error.not.found.analysis=The sentence was analyzed like this\:
-ltc.editor.error.no.marker=No <marker> found in incorrect example sentence
+ltc.editor.error.no.marker=No &lt;marker&gt; found in incorrect example sentence
 ltc.editor.error.unexpected=The rule found an unexpected error in ''{0}''
 ltc.editor.error.wrong.correction=Found wrong correction(s) in sentence ''{0}''\: ''{1}'' but expected ''{2}''
-ltc.editor.error.marker.start=Unexpected start position of <marker>...</marker> in incorrect example sentence\: {0} but expected {1}
-ltc.editor.error.marker.end=Unexpected end position of <marker>...</marker> in incorrect example sentence\: {0} but expected {1}
+ltc.editor.error.marker.start=Unexpected start position of &lt;marker&gt;...&lt;/marker&gt; in incorrect example sentence\: {0} but expected {1}
+ltc.editor.error.marker.end=Unexpected end position of &lt;marker&gt;...&lt;/marker&gt; in incorrect example sentence\: {0} but expected {1}
 ltc.editor.error.incorrect.example.needed=To continue, you will need to will need to add an example to the "Sentence with error" field above
 
 ltc.editor.corpus.intro=We''ve checked your pattern against {0} sentences from the {1} <a href\="http\://www.wikipedia.org" target\="_blank">Wikipedia</a> and from <a href\="http\://tatoeba.org" target\="_blank">Tatoeba</a> found no matches. That''s a good sign, it means your rule doesn''t trigger any false alarms at least in the documents we checked.


### PR DESCRIPTION
This fixes the incomprehensible error messages I received at http://community.languagetool.org/ruleEditor/expert
- No found in incorrect example sentence
- Unexpected start position of ... in incorrect example sentence:
