### PR TITLE
Made ltc.wikicheck.summary.preset completely translateable

### DIFF
--- a/grails-app/conf/Config.groovy
+++ b/grails-app/conf/Config.groovy
@@ -9,6 +9,10 @@
 // if(System.properties["${appName}.config.location"]) {
 //    grails.config.locations << "file:" + System.properties["${appName}.config.location"]
 // }
+
+wikipedia.summary.link = [ en: '[[LanguageTool]]',
+                           de: '[[WP:LanguageTool]]' ]
+
 grails.mime.file.extensions = true // enables the parsing of file extensions from URLs into the request format
 grails.mime.types = [ html: ['text/html','application/xhtml+xml'],
                       xml: ['text/xml', 'application/xml'],

--- a/grails-app/views/wikiCheck/pageCheck.gsp
+++ b/grails-app/views/wikiCheck/pageCheck.gsp
@@ -105,7 +105,13 @@
                     <g:hiddenField name="oldId" value="0"/>
                     <g:hiddenField name="format" value="text/x-wiki"/>
                     <g:hiddenField name="model" value="wikitext"/>
-                    <g:hiddenField name="wpSummary" value="LanguageTool: ${message(code: 'ltc.wikicheck.summary.preset')}"/>
+                    <g:if test="${grailsApplication.config.wikipedia.summary.link}.contains(lang.shortName)">
+                        <g:set var="wikipediaLink" value="${grailsApplication.config.wikipedia.summary.link[lang.shortName]}:"/>
+                    </g:if>
+                    <g:else>
+                        <g:set var="wikipediaLink" value="LanguageTool:"/>
+                    </g:else>
+                    <g:hiddenField name="wpSummary" value="${wikipediaLink} ${message(code: 'ltc.wikicheck.summary.preset')}"/>
                     <g:hiddenField name="wpDiff" value="yes"/>
                     <g:hiddenField name="wpMinoredit" value="1"/>
                     <!-- this will be modified at submit: -->


### PR DESCRIPTION
This removes the hard-coded string `LanguageTool:` and replaces it with MediaWiki syntax for languages where Wikipedia articles about it exist as suggested in http://languagetool-user-forum.2306527.n4.nabble.com/Suggestion-for-improved-Wikipedia-edit-summary-tp4641562.html.
