### PR TITLE
Moved to the Wikimedia Foundation Labs server infrastructure

### DIFF
--- a/grails-app/conf/Config.groovy
+++ b/grails-app/conf/Config.groovy
@@ -54,11 +54,11 @@ hide.languages = ["cs", "ml", "be", "da", "sk", "zh", "ast", "km", "en-GB", "en-
 expose.languages = ["en", "fr", "de", "es", "pl", "ca", "br", "nl", "pt", "es", "eo"]
 maxPatternElements = 5
 // disable some rules for WikiCheck to avoid too many false alarms:
-disabledRulesPropFile="/home/languagetool/ltcommunity/corpus/ltcommunity/disabled_rules.properties"
-disabledRulesForFeedPropFile="/home/languagetool/ltcommunity/corpus/ltcommunity/disabled_rules_for_feed.properties"
+disabledRulesPropFile="/data/project/languagetool/ltcommunity/corpus/wikicheck/disabled_rules.properties"
+disabledRulesForFeedPropFile="/data/project/languagetool/ltcommunity/corpus/wikicheck/disabled_rules_for_feed.properties"
 
 // Lucene index directories for fast rule matching - "LANG" will be replaced with the language code:
-fastSearchIndex = "/home/languagetool/corpus/LANG"
+fastSearchIndex = "/data/project/languagetool/corpus/LANG"
 fastSearchTimeoutMillis = 15000
 
 // log4j configuration

--- a/grails-app/conf/DataSource.groovy
+++ b/grails-app/conf/DataSource.groovy
@@ -19,8 +19,8 @@ environments {
 		    driverClassName = "com.mysql.jdbc.Driver"
 			dbCreate = "update" // one of 'create', 'create-drop','update'
 			url = "jdbc:mysql://localhost/ltcommunity?useUnicode=true&characterEncoding=UTF-8"
-		    username = "root"
-		    password = ""
+			username = "root"
+			password = ""
 		}
 	}
 	test {
@@ -31,11 +31,11 @@ environments {
 	}
 	production {
 		dataSource {
-		  driverClassName = "com.mysql.jdbc.Driver"
-		  dbCreate = "update" // one of 'create', 'create-drop','update'
-          url = "jdbc:mysql://localhost/ltcommunity?useUnicode=true&characterEncoding=UTF-8"
-          username = ""
-          password = ""
+			driverClassName = "com.mysql.jdbc.Driver"
+			dbCreate = "update" // one of 'create', 'create-drop','update'
+			url = "jdbc:mysql://tools-db/s52131__ltcommunity?useUnicode=true&characterEncoding=UTF-8"
+			username = "s52131"
+			password = ""
 		}
 	}
 }


### PR DESCRIPTION
These are the necessary changes to the configuration required to run it at http://tools.wmflabs.org/. This is meant for documentation purposes. Deployment is not yet automatized although I wrote some scripts so I don't forget.
- Change the configuration files as stated in this pull request.
- Get the password (does not work via SFTP, permission denied):

``` bash
ssh username@tools-login.wmflabs.org
become languagetool
nano replica.my.cnf
```
- Build the WAR as instructed in https://github.com/languagetool-org/languagetool-community-website/pull/16 locally. I have not yet managed to get grails/mvn to work on the WMF server although it may be preferable to just update from git and build there to avoid a 100 MB upload with slow ADSL.
- Upload the WAR and deploy as following. The exact file name is important.

``` bash
scp target/ltcommunity-0.1.war username@tools-login.wmflabs.org:/data/project/languagetool/
ssh username@tools-login.wmflabs.org
become languagetool
webservice -tomcat stop
rm -rf public_tomcat/webapps/*
mv ltcommunity-0.1.war public_tomcat/webapps/languagetool.war
webservice -tomcat start
webservice -tomcat restart
```

Wait a moment. This takes several minutes. Almost every deployment/configuration error results in 404 for no apparent reason and is not properly displayed on the web. I found `/data/project/languagetool/error.log` to be the most helpful one. There are also some in `/data/project/languagetool/public_tomcat/logs/`

Most parts of http://tools.wmflabs.org/languagetool/ already work. I could not find the corpus files and the recent changes feed is not setup correctly, but now that we have access to live Wikipedia DB replicates, this has to be re-implemented anyway.
